### PR TITLE
switch dynamic navigation links to static for more control

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,12 +17,16 @@
         </label>
 
         <div class="trigger">
+          <!--
           {%- for path in page_paths -%}
             {%- assign my_page = site.pages | where: "path", path | first -%}
             {%- if my_page.title -%}
             <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
             {%- endif -%}
           {%- endfor -%}
+          -->
+          <a class="page-link" href="/categories/">Categories</a>
+          <a class="page-link" href="/about/">About me</a>
         </div>
       </nav>
     {%- endif -%}


### PR DESCRIPTION
Replace the dynamic navigation link generation with hard coded static links. This is because I didn't want to change the entire logic behind the original loop to give me the few sites I have in correct order.
Made this an PR for #Hacktoberfest