### PR TITLE
remove weird left margin from mobile menu links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,8 +25,8 @@
             {%- endif -%}
           {%- endfor -%}
           -->
-          <a class="page-link" href="/categories/">Categories</a>
-          <a class="page-link" href="/about/">About me</a>
+          <a class="page-link no-margin-left" href="/categories/">Categories</a>
+          <a class="page-link no-margin-left" href="/about/">About me</a>
         </div>
       </nav>
     {%- endif -%}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -35,4 +35,8 @@
 
 html { 
     scroll-behavior: smooth; 
-} 
+}
+
+.no-margin-left {
+    margin-left: 0px !important; 
+}


### PR DESCRIPTION
Overwrites the imo weird 20px left margin from the Jekyll minima theme. This was only visible for mobile users, when the media-query kicked in. 
PR for Hacktoberfest.